### PR TITLE
Disabling the sytem include path feature and marking it as deprecated

### DIFF
--- a/com.piece_framework.makegood.aspect.org.eclipse.php.core/src/com/piece_framework/makegood/aspect/org/eclipse/php/core/AspectManifest.java
+++ b/com.piece_framework.makegood.aspect.org.eclipse.php.core/src/com/piece_framework/makegood/aspect/org/eclipse/php/core/AspectManifest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2011 KUBO Atsuhiro <kubo@iteman.jp>,
+ * Copyright (c) 2010-2011, 2015 KUBO Atsuhiro <kubo@iteman.jp>,
  * All rights reserved.
  *
  * This file is part of MakeGood.
@@ -12,21 +12,11 @@
 package com.piece_framework.makegood.aspect.org.eclipse.php.core;
 
 import com.piece_framework.makegood.aspect.Aspect;
+import com.piece_framework.makegood.aspect.PDTVersion;
 import com.piece_framework.makegood.aspect.org.eclipse.php.core.aspect.MultibyteCharactersAspect;
 import com.piece_framework.makegood.aspect.org.eclipse.php.core.aspect.SystemIncludePathAspect;
 
 public class AspectManifest implements com.piece_framework.makegood.aspect.AspectManifest {
-    private static final Aspect[] ASPECTS = {
-        new SystemIncludePathAspect(),
-        new MultibyteCharactersAspect(),
-    };
-    private static final String[] DEPENDENCIES = {
-        "org.eclipse.php.core", //$NON-NLS-1$
-        "org.eclipse.core.resources", //$NON-NLS-1$
-        "org.eclipse.dltk.core", //$NON-NLS-1$
-        "com.piece_framework.makegood.includepath", //$NON-NLS-1$
-    };
-
     @Override
     public String pluginId() {
         return Fragment.PLUGIN_ID;
@@ -34,11 +24,31 @@ public class AspectManifest implements com.piece_framework.makegood.aspect.Aspec
 
     @Override
     public Aspect[] aspects() {
-        return ASPECTS;
+        if (PDTVersion.getInstance().compareTo("3.5.0") >= 0) { //$NON-NLS-1$
+            return new Aspect[] {
+                new MultibyteCharactersAspect(),
+            };
+        } else {
+            return new Aspect[] {
+                new SystemIncludePathAspect(),
+                new MultibyteCharactersAspect(),
+            };
+        }
     }
 
     @Override
     public String[] dependencies() {
-        return DEPENDENCIES;
+        if (PDTVersion.getInstance().compareTo("3.5.0") >= 0) { //$NON-NLS-1$
+            return new String[] {
+                "org.eclipse.php.core", //$NON-NLS-1$
+            };
+        } else {
+            return new String[] {
+                "org.eclipse.php.core", //$NON-NLS-1$
+                "org.eclipse.core.resources", //$NON-NLS-1$
+                "org.eclipse.dltk.core", //$NON-NLS-1$
+                "com.piece_framework.makegood.includepath", //$NON-NLS-1$
+            };
+        }
     }
 }

--- a/com.piece_framework.makegood.aspect.org.eclipse.php.core/src/com/piece_framework/makegood/aspect/org/eclipse/php/core/aspect/SystemIncludePathAspect.java
+++ b/com.piece_framework.makegood.aspect.org.eclipse.php.core/src/com/piece_framework/makegood/aspect/org/eclipse/php/core/aspect/SystemIncludePathAspect.java
@@ -23,6 +23,9 @@ import javassist.expr.MethodCall;
 
 import com.piece_framework.makegood.aspect.Aspect;
 
+/**
+ * @deprecated Deprecated since version 3.2, to be removed in 4.0.
+ */
 public class SystemIncludePathAspect extends Aspect {
     private static final String JOINPOINT_CAST_ICONTAINER = "PHPSearchEngine#find [cast IContainer]"; //$NON-NLS-1$
     private static final String JOINPOINT_CALL_FINDMEMBER = "PHPSearchEngine#find [call findMember()]"; //$NON-NLS-1$

--- a/com.piece_framework.makegood.aspect.org.eclipse.php.debug.core/src/com/piece_framework/makegood/aspect/org/eclipse/php/debug/core/AspectManifest.java
+++ b/com.piece_framework.makegood.aspect.org.eclipse.php.debug.core/src/com/piece_framework/makegood/aspect/org/eclipse/php/debug/core/AspectManifest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2011, 2014 KUBO Atsuhiro <kubo@iteman.jp>,
+ * Copyright (c) 2010-2011, 2014-2015 KUBO Atsuhiro <kubo@iteman.jp>,
  * All rights reserved.
  *
  * This file is part of MakeGood.
@@ -12,6 +12,7 @@
 package com.piece_framework.makegood.aspect.org.eclipse.php.debug.core;
 
 import com.piece_framework.makegood.aspect.Aspect;
+import com.piece_framework.makegood.aspect.PDTVersion;
 import com.piece_framework.makegood.aspect.org.eclipse.php.debug.core.aspect.SystemIncludePathAspect;
 import com.piece_framework.makegood.aspect.org.eclipse.php.debug.core.aspect.XdebugLaunchAspect;
 
@@ -23,20 +24,35 @@ public class AspectManifest implements com.piece_framework.makegood.aspect.Aspec
 
     @Override
     public Aspect[] aspects() {
-        return new Aspect[] {
-            new XdebugLaunchAspect(),
-            new SystemIncludePathAspect(),
-        };
+        if (PDTVersion.getInstance().compareTo("3.5.0") >= 0) { //$NON-NLS-1$
+            return new Aspect[] {
+                new XdebugLaunchAspect(),
+            };
+        } else {
+            return new Aspect[] {
+                new XdebugLaunchAspect(),
+                new SystemIncludePathAspect(),
+            };
+        }
     }
 
     @Override
     public String[] dependencies() {
-        return new String[] {
-            Fragment.PLUGIN_ID,
-            "org.eclipse.equinox.common", //$NON-NLS-1$
-            "org.eclipse.php.debug.core", //$NON-NLS-1$
-            "com.piece_framework.makegood.launch", //$NON-NLS-1$
-            "org.eclipse.debug.core", //$NON-NLS-1$
-        };
+        if (PDTVersion.getInstance().compareTo("3.5.0") >= 0) { //$NON-NLS-1$
+            return new String[] {
+                "org.eclipse.core.resources", //$NON-NLS-1$
+                "org.eclipse.equinox.common", //$NON-NLS-1$
+                "org.eclipse.php.debug.core", //$NON-NLS-1$
+                "com.piece_framework.makegood.launch", //$NON-NLS-1$
+            };
+        } else {
+            return new String[] {
+                Fragment.PLUGIN_ID,
+                "org.eclipse.equinox.common", //$NON-NLS-1$
+                "org.eclipse.php.debug.core", //$NON-NLS-1$
+                "com.piece_framework.makegood.launch", //$NON-NLS-1$
+                "org.eclipse.debug.core", //$NON-NLS-1$
+            };
+        }
     }
 }

--- a/com.piece_framework.makegood.aspect.org.eclipse.php.debug.core/src/com/piece_framework/makegood/aspect/org/eclipse/php/debug/core/aspect/SystemIncludePathAspect.java
+++ b/com.piece_framework.makegood.aspect.org.eclipse.php.debug.core/src/com/piece_framework/makegood/aspect/org/eclipse/php/debug/core/aspect/SystemIncludePathAspect.java
@@ -23,6 +23,9 @@ import javassist.expr.MethodCall;
 
 import com.piece_framework.makegood.aspect.Aspect;
 
+/**
+ * @deprecated Deprecated since version 3.2, to be removed in 4.0.
+ */
 public class SystemIncludePathAspect extends Aspect {
     private static final String JOINPOINT_CAST_ICONTAINER =
         "PHPINIUtil#createPhpIniByProject() [cast IContainer]"; //$NON-NLS-1$

--- a/com.piece_framework.makegood.aspect.org.eclipse.php.ui/src/com/piece_framework/makegood/aspect/org/eclipse/php/ui/AspectManifest.java
+++ b/com.piece_framework.makegood.aspect.org.eclipse.php.ui/src/com/piece_framework/makegood/aspect/org/eclipse/php/ui/AspectManifest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2011, 2014 KUBO Atsuhiro <kubo@iteman.jp>,
+ * Copyright (c) 2010-2011, 2014-2015 KUBO Atsuhiro <kubo@iteman.jp>,
  * All rights reserved.
  *
  * This file is part of MakeGood.
@@ -18,40 +18,41 @@ import java.util.List;
 import org.eclipse.core.runtime.Platform;
 
 import com.piece_framework.makegood.aspect.Aspect;
+import com.piece_framework.makegood.aspect.PDTVersion;
 import com.piece_framework.makegood.aspect.org.eclipse.php.ui.aspect.SystemIncludePathAspect;
 
 public class AspectManifest implements com.piece_framework.makegood.aspect.AspectManifest {
-    private static final Aspect[] ASPECTS = {
-        new SystemIncludePathAspect(),
-    };
-    private static List<String> DEPENDENCIES = new ArrayList<String>(Arrays.asList(
-        "org.eclipse.php.ui", //$NON-NLS-1$
-        "org.eclipse.dltk.ui", //$NON-NLS-1$
-        "org.eclipse.jface", //$NON-NLS-1$
-        Fragment.PLUGIN_ID,
-        "org.eclipse.core.commands" //$NON-NLS-1$
-    ));
+    private static List<String> DEPENDENCIES = new ArrayList<String>();
 
     static {
-        String os = Platform.getOS();
-        String osArch = Platform.getOSArch();
-        if (Platform.OS_LINUX.equals(os)) {
-            if (Platform.ARCH_X86_64.equals(osArch)) {
-                DEPENDENCIES.add("org.eclipse.swt.gtk.linux.x86_64"); //$NON-NLS-1$
-            } else if (Platform.ARCH_X86.equals(osArch)) {
-                DEPENDENCIES.add("org.eclipse.swt.gtk.linux.x86"); //$NON-NLS-1$
-            }
-        } else if (Platform.OS_MACOSX.equals(os)) {
-            if (Platform.ARCH_X86_64.equals(osArch)) {
-                DEPENDENCIES.add("org.eclipse.swt.cocoa.macosx.x86_64"); //$NON-NLS-1$
-            } else if (Platform.ARCH_X86.equals(osArch)) {
-                DEPENDENCIES.add("org.eclipse.swt.cocoa.macosx"); //$NON-NLS-1$
-            }
-        } else if (Platform.OS_WIN32.equals(os)) {
-            if (Platform.ARCH_X86_64.equals(osArch)) {
-                DEPENDENCIES.add("org.eclipse.swt.win32.win32.x86_64"); //$NON-NLS-1$
-            } else if (Platform.ARCH_X86.equals(osArch)) {
-                DEPENDENCIES.add("org.eclipse.swt.win32.win32.x86"); //$NON-NLS-1$
+        if (PDTVersion.getInstance().compareTo("3.5.0") < 0) { //$NON-NLS-1$
+            DEPENDENCIES.addAll(Arrays.asList(
+                "org.eclipse.php.ui", //$NON-NLS-1$
+                "org.eclipse.dltk.ui", //$NON-NLS-1$
+                "org.eclipse.jface", //$NON-NLS-1$
+                Fragment.PLUGIN_ID, "org.eclipse.core.commands" //$NON-NLS-1$
+            ));
+
+            String os = Platform.getOS();
+            String osArch = Platform.getOSArch();
+            if (Platform.OS_LINUX.equals(os)) {
+                if (Platform.ARCH_X86_64.equals(osArch)) {
+                    DEPENDENCIES.add("org.eclipse.swt.gtk.linux.x86_64"); //$NON-NLS-1$
+                } else if (Platform.ARCH_X86.equals(osArch)) {
+                    DEPENDENCIES.add("org.eclipse.swt.gtk.linux.x86"); //$NON-NLS-1$
+                }
+            } else if (Platform.OS_MACOSX.equals(os)) {
+                if (Platform.ARCH_X86_64.equals(osArch)) {
+                    DEPENDENCIES.add("org.eclipse.swt.cocoa.macosx.x86_64"); //$NON-NLS-1$
+                } else if (Platform.ARCH_X86.equals(osArch)) {
+                    DEPENDENCIES.add("org.eclipse.swt.cocoa.macosx"); //$NON-NLS-1$
+                }
+            } else if (Platform.OS_WIN32.equals(os)) {
+                if (Platform.ARCH_X86_64.equals(osArch)) {
+                    DEPENDENCIES.add("org.eclipse.swt.win32.win32.x86_64"); //$NON-NLS-1$
+                } else if (Platform.ARCH_X86.equals(osArch)) {
+                    DEPENDENCIES.add("org.eclipse.swt.win32.win32.x86"); //$NON-NLS-1$
+                }
             }
         }
     }
@@ -63,7 +64,14 @@ public class AspectManifest implements com.piece_framework.makegood.aspect.Aspec
 
     @Override
     public Aspect[] aspects() {
-        return ASPECTS;
+        if (PDTVersion.getInstance().compareTo("3.5.0") >= 0) { //$NON-NLS-1$
+            return new Aspect[] {
+            };
+        } else {
+            return new Aspect[] {
+                new SystemIncludePathAspect(),
+            };
+        }
     }
 
     @Override

--- a/com.piece_framework.makegood.aspect.org.eclipse.php.ui/src/com/piece_framework/makegood/aspect/org/eclipse/php/ui/aspect/SystemIncludePathAspect.java
+++ b/com.piece_framework.makegood.aspect.org.eclipse.php.ui/src/com/piece_framework/makegood/aspect/org/eclipse/php/ui/aspect/SystemIncludePathAspect.java
@@ -21,6 +21,9 @@ import javassist.expr.NewExpr;
 
 import com.piece_framework.makegood.aspect.Aspect;
 
+/**
+ * @deprecated Deprecated since version 3.2, to be removed in 4.0.
+ */
 public class SystemIncludePathAspect extends Aspect {
     private static final String JOINPOINT_GETCPLISTELEMENTTEXT_INSERTBEFORE =
         "PHPIPListLabelProvider#getCPListElementText() [insert before]"; //$NON-NLS-1$

--- a/com.piece_framework.makegood.includepath/src/com/piece_framework/makegood/includepath/decorators/SystemIncludePathLabelDecorator.java
+++ b/com.piece_framework.makegood.includepath/src/com/piece_framework/makegood/includepath/decorators/SystemIncludePathLabelDecorator.java
@@ -19,6 +19,9 @@ import org.eclipse.swt.graphics.Image;
 
 import com.piece_framework.makegood.includepath.ConfigurationIncludePath;
 
+/**
+ * @deprecated Deprecated since version 3.2, to be removed in 4.0.
+ */
 public class SystemIncludePathLabelDecorator implements ILabelDecorator {
     @Override
     public String decorateText(String text, Object element) {


### PR DESCRIPTION
An aspect for the system include path feature cannot be weaved in PDT 3.5. #77